### PR TITLE
Rc v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# [0.3.0](https://github.com/wel-shy/committer/compare/0.2.1...0.3.0) (2019-04-10)
+
+### Features
+
+- adding pushing commits :sparkles: [#7](https://github.com/wel-shy/committer/issues/7) ([57aa206](https://github.com/wel-shy/committer/commit/57aa206))
+
+## [0.2.1](https://github.com/wel-shy/committer/compare/0.2.0...0.2.1) (2019-04-10)
+
+### Bug Fixes
+
+- fixing misnamed imports in index.ts :bug: ([b908439](https://github.com/wel-shy/committer/commit/b908439))
+
 # [0.2.0](https://github.com/wel-shy/committer/compare/0.1.1...0.2.0) (2019-04-09)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ conventional-committer
 
 - Auto add untracked changes with a `-a` flag.
 - Sign commits with `-s`, requires setting a gpg key for git.
+- Push after commit with `-p`.
+
+Options can be stacked, you can sign and push with `-sp` for example.
 
 ## Test
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "conventional-committer",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conventional-committer",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Commit manager",
   "main": "dist/src/index.js",
   "scripts": {

--- a/src/App.ts
+++ b/src/App.ts
@@ -65,22 +65,22 @@ export default class App {
 
     cmd = `${cmd} -m '${message}'`;
 
+    if (options) {
+      if (options.push) {
+        cmd = `${cmd} && git push`;
+      }
+    }
+
     try {
       await this.executeCommand(cmd);
       console.log(chalk.green("Changes committed"));
-    } catch (e) {
-      throw e;
-    }
-
-    if (options) {
-      if (options.push) {
-        try {
-          await this.executeCommand("git push");
-          console.log(chalk.green("Pushed commit"));
-        } catch (e) {
-          throw e;
+      if (options) {
+        if (options.push) {
+          console.log(chalk.green("Commit pushed"));
         }
       }
+    } catch (e) {
+      throw e;
     }
 
     return "commit successful";

--- a/src/App.ts
+++ b/src/App.ts
@@ -46,7 +46,7 @@ export default class App {
    */
   public async commitChanges(
     message: string,
-    options?: { add: boolean; sign: boolean }
+    options?: { add: boolean; sign: boolean; push: boolean }
   ): Promise<string> {
     let cmd: string = "git commit";
 
@@ -68,10 +68,22 @@ export default class App {
     try {
       await this.executeCommand(cmd);
       console.log(chalk.green("Changes committed"));
-      return "commit successful";
     } catch (e) {
       throw e;
     }
+
+    if (options) {
+      if (options.push) {
+        try {
+          await this.executeCommand("git push");
+          console.log(chalk.green("Pushed commit"));
+        } catch (e) {
+          throw e;
+        }
+      }
+    }
+
+    return "commit successful";
   }
 
   /**

--- a/src/CLI.ts
+++ b/src/CLI.ts
@@ -57,7 +57,8 @@ export class CLI {
       require("inquirer-autocomplete-prompt")
     );
 
-    return inquirer.prompt(questions) as Promise<CliAnswer>;
+    const ans: any = await inquirer.prompt(questions);
+    return ans as CliAnswer;
   }
 
   /**
@@ -86,7 +87,7 @@ export class CLI {
   public filterResponses(answersSoFar: any, input: string): Promise<string[]> {
     return new Promise(resolve => {
       // map to string
-      const mapped: string[] = this.getEmojisAsString();
+      const mapped: string[] = CLI.getEmojisAsString();
 
       // format input
       if (input === undefined) {
@@ -105,7 +106,7 @@ export class CLI {
    * Map emoji to string
    * @return [description]
    */
-  public getEmojisAsString(): string[] {
+  public static getEmojisAsString(): string[] {
     return emojis.gitmojis.map(
       gitmoji => `${gitmoji.emoji.trim()} - ${gitmoji.description.trim()}`
     );

--- a/src/Index.ts
+++ b/src/Index.ts
@@ -2,7 +2,7 @@
 
 import App from "./App";
 // @ts-ignore
-import { version } from "../../package.json";
+import { version } from "../package.json";
 import chalk from "chalk";
 import { CLI } from "./CLI";
 
@@ -23,10 +23,15 @@ async function exe(): Promise<void> {
   commander
     .option("-s, --sign", "sign commit with gpg key")
     .option("-a, --add", "add all untracked changes")
-    .option("-c, --config", "edit committer config");
+    .option("-c, --config", "edit committer config")
+    .option("-p, --push", "push commit");
 
   commander.parse(process.argv);
-  const options = { sign: commander.sign, add: commander.add };
+  const options = {
+    sign: commander.sign,
+    add: commander.add,
+    push: commander.push
+  };
 
   const app: App = new App();
   const cli: CLI = new CLI();

--- a/src/__test__/App.spec.ts
+++ b/src/__test__/App.spec.ts
@@ -84,7 +84,7 @@ describe("App", () => {
   describe(".commitChanges", () => {
     it("Should commit changes", async () => {
       const testString = "test string";
-      const response = await app.commitChanges(testString);
+      await app.commitChanges(testString);
       expect(exec).toBeCalledWith(
         `git commit -m '${testString}'`,
         expect.anything()
@@ -93,9 +93,10 @@ describe("App", () => {
 
     it("Should commit changes and stage untracked changes", async () => {
       const testString = "test string";
-      const response = await app.commitChanges(testString, {
+      await app.commitChanges(testString, {
         add: true,
-        sign: false
+        sign: false,
+        push: false
       });
       expect(exec).toBeCalledWith(`git add .`, expect.anything());
 
@@ -107,9 +108,10 @@ describe("App", () => {
 
     it("Should commit changes and sign the commit", async () => {
       const testString = "test string";
-      const response = await app.commitChanges(testString, {
+      await app.commitChanges(testString, {
         add: false,
-        sign: true
+        sign: true,
+        push: false
       });
       expect(exec).toBeCalledWith(
         `git commit -S -m '${testString}'`,
@@ -119,9 +121,10 @@ describe("App", () => {
 
     it("Should commit changes, sign the commit, and add untracked", async () => {
       const testString = "test string";
-      const response = await app.commitChanges(testString, {
+      await app.commitChanges(testString, {
         add: true,
-        sign: true
+        sign: true,
+        push: false
       });
       expect(exec).toBeCalledWith(`git add .`, expect.anything());
       expect(exec).toBeCalledWith(
@@ -130,12 +133,28 @@ describe("App", () => {
       );
     });
 
+    it("Should commit changes, sign the commit, and add untracked", async () => {
+      const testString = "test string";
+      await app.commitChanges(testString, {
+        add: true,
+        sign: true,
+        push: true
+      });
+      expect(exec).toBeCalledWith(`git add .`, expect.anything());
+      expect(exec).toBeCalledWith(
+        `git commit -S -m '${testString}'`,
+        expect.anything()
+      );
+      expect(exec).toBeCalledWith(`git push`, expect.anything());
+    });
+
     it("Should throw an error on bad commit", async () => {
       const testString = "error";
       await expect(
         app.commitChanges(testString, {
           add: true,
-          sign: true
+          sign: true,
+          push: false
         })
       ).rejects.toThrow();
     });

--- a/src/__test__/App.spec.ts
+++ b/src/__test__/App.spec.ts
@@ -7,6 +7,8 @@ jest.mock("child_process", () => {
     exec: jest.fn((cmd: string, cb: any) => {
       if (/error/.test(cmd)) {
         return cb(new Error());
+      } else if (cmd.indexOf("error") != -1 && cmd.indexOf("git push") != -1) {
+        return cb(new Error());
       } else {
         return cb(null, "called", "");
       }
@@ -145,7 +147,10 @@ describe("App", () => {
         `git commit -S -m '${testString}'`,
         expect.anything()
       );
-      expect(exec).toBeCalledWith(`git push`, expect.anything());
+      expect(exec).toBeCalledWith(
+        `git commit -S -m '${testString}' && git push`,
+        expect.anything()
+      );
     });
 
     it("Should throw an error on bad commit", async () => {
@@ -155,6 +160,17 @@ describe("App", () => {
           add: true,
           sign: true,
           push: false
+        })
+      ).rejects.toThrow();
+    });
+
+    it("Should throw an error on bad push", async () => {
+      const testString = "error";
+      await expect(
+        app.commitChanges(testString, {
+          add: true,
+          sign: true,
+          push: true
         })
       ).rejects.toThrow();
     });


### PR DESCRIPTION
# Adding Pushing Commits :sparkles:

Commits can be immediately pushed after committing with the `-p` flag.

Fixes #7 

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [X] Requires a documentation update

## Testing Description
Added tests for pushing commits and catching failed pushes.